### PR TITLE
#32 Only process markdown

### DIFF
--- a/dynamic_math.js
+++ b/dynamic_math.js
@@ -1,7 +1,8 @@
 function render_preview() {
     $(".js-preview-tab").on("click", function(e) {
         function didLoadPreview() {
-            if (!$(".js-preview-tab").hasClass('selected')) {
+            let tab = $(".js-preview-tab");
+            if (!tab.hasClass('selected') && !tab.attr("aria-selected")) {
                 return;
             }
             if ($(".preview-content").attr('display') == 'none') {

--- a/mathjax_config.js
+++ b/mathjax_config.js
@@ -4,6 +4,8 @@ window.MathJax = {
   tex2jax: {
     inlineMath: [ ["$","$"] ],
     displayMath: [ ["$$","$$"] ],
+    ignoreClass: "application-main",
+    processClass: "markdown-body",
     processEscapes: true
   },
   imageFont: null,


### PR DESCRIPTION
Hi Or,

I'm not quite sure you want that change — as far as I can tell, it changes semantics a lot; still, it may be useful, so if you need it, here's it :) 

Basically, many source files have `$` signs where they are not meant to mean $\LaTeX\ here!$ — e.g. Scala's interpolated strings:

```scala
val name = "World"
println(s"Hello $name! How are you, $name?")
```

I also added support for the PR dialog preview tab — its selection class was changed,